### PR TITLE
hdfs port 9000 listen on local ip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - tso
       - hdfs
     ports:
-      - "9000:52145"
+      - "127.0.0.1:9000:52145"
       - "8123:21557"
     container_name: server-0
     volumes:

--- a/docker-compose.yml.multiworkers
+++ b/docker-compose.yml.multiworkers
@@ -88,7 +88,7 @@ services:
       - tso
       - hdfs
     ports:
-      - "9000:52145"
+      - "127.0.0.1:9000:52145"
       - "8123:21557"
     container_name: server-0
     volumes:


### PR DESCRIPTION
I had opened an issue with that problem: https://github.com/ByConity/byconity-docker/issues/19

In a word, the modification is just to make the port of 9000 listened by local ip, instead of 0.0.0.0

The result is as below:
<img width="838" alt="image" src="https://github.com/ByConity/byconity-docker/assets/2918487/75ef5412-7590-4253-ba40-e81667fe5487">

Correct me if I am wrong, thanks.
